### PR TITLE
Add Rust server for local Solana RPC proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,30 +10,79 @@ Fuego provides autonomous agents with a lightweight, local wallet implementation
 
 - 🔐 **Local Key Management** - Keys never leave the agent's machine
 - 🚀 **Solana Native** - Direct integration with Solana RPC
+- 🦀 **Rust Server** - High-performance local RPC proxy for agents
 - 🤖 **Agent-First** - Built for autonomous operation
 - ⚡ **Fast** - Minimal dependencies, low overhead
 - 📦 **OpenClaw Compatible** - Designed as an OpenClaw skill/tool
 
 ## Installation
 
+### TypeScript Wallet
 ```bash
 git clone https://github.com/willmcdeezy/fuego.git
 cd fuego
 npm install
 ```
 
+### Rust Server (Optional - for local RPC)
+```bash
+cd fuego/server
+cargo build --release
+```
+
+## Architecture
+
+Fuego consists of two components:
+
+1. **TypeScript Wallet** (`src/`) - Secure key management and signing
+2. **Rust Server** (`server/`) - Local RPC proxy for balance/hash queries
+
 ## Usage
 
+### Wallet (TypeScript)
 ```typescript
 import { FuegoWallet } from './fuego'
 
 const wallet = new FuegoWallet()
-const balance = await wallet.getBalance()
+await wallet.authenticate('your-password')
+const address = wallet.getAddress()
+```
+
+### Server (Rust) - Run locally on :8080
+```bash
+cd server
+cargo run
+# Server starts on http://127.0.0.1:8080
+```
+
+**Server Endpoints:**
+- `POST /latest-hash` - Get latest blockhash
+  ```json
+  { "network": "mainnet-beta" }
+  ```
+- `POST /balance` - Get SOL balance
+  ```json
+  { "network": "mainnet-beta", "address": "abc123..." }
+  ```
+- `GET /health` - Health check
+- `GET /network` - Get default network
+
+Agents can query the local server instead of hitting RPC directly:
+```typescript
+// From fuego client
+const response = await fetch('http://127.0.0.1:8080/balance', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ network: 'mainnet-beta', address: wallet.getAddress() })
+})
+const { data } = await response.json()
+console.log(`Balance: ${data.sol} SOL`)
 ```
 
 ## Development
 
-Built with TypeScript + Solana Web3.js
+- **Wallet**: TypeScript + Solana Web3.js
+- **Server**: Rust + Tokio + Axum + Solana Client
 
 ## License
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "fuego-server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.5.2", features = ["cors"] }
+axum = "0.7.5"
+serde_json = "1.0.115"
+serde = "1.0.196"
+solana-client = "2.0.7"
+solana-sdk = "2.0.7"
+chrono = { version = "0.4.34", features = ["serde", "clock"] }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,0 +1,147 @@
+mod utils;
+
+use axum::{
+    extract::State,
+    http::Method,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use solana_client::rpc_client::RpcClient;
+use solana_sdk::commitment_config::CommitmentConfig;
+use std::net::SocketAddr;
+use tower_http::cors::{Any, CorsLayer};
+use utils::string_to_pub_key;
+
+#[derive(Serialize, Deserialize)]
+struct RpcNetwork {
+    network: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct GetBalanceRequest {
+    network: String,
+    address: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct BalanceResponse {
+    lamports: u64,
+    sol: f64,
+}
+
+// State to hold RPC clients (could be expanded for caching)
+#[derive(Clone)]
+struct AppState {
+    default_network: String,
+}
+
+async fn health_check() -> impl IntoResponse {
+    Json(json!({
+        "status": "healthy",
+        "service": "fuego-server",
+        "version": "0.1.0"
+    }))
+}
+
+async fn get_latest_hash(
+    State(_state): State<AppState>,
+    Json(payload): Json<RpcNetwork>,
+) -> Response {
+    let rpc_url = format!("https://api.{}.solana.com", payload.network);
+    let rpc = RpcClient::new(rpc_url);
+
+    match rpc.get_latest_blockhash() {
+        Ok(blockhash) => Json(json!({
+            "success": true,
+            "data": {
+                "blockhash": blockhash.to_string(),
+                "network": payload.network
+            }
+        })).into_response(),
+        Err(e) => Json(json!({
+            "success": false,
+            "error": format!("Failed to get latest blockhash: {}", e)
+        })).into_response(),
+    }
+}
+
+async fn get_balance(
+    State(_state): State<AppState>,
+    Json(payload): Json<GetBalanceRequest>,
+) -> Response {
+    let rpc_url = format!("https://api.{}.solana.com", payload.network);
+    let rpc = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+
+    let pubkey = match string_to_pub_key(&payload.address) {
+        Ok(pk) => pk,
+        Err(_) => {
+            return Json(json!({
+                "success": false,
+                "error": "Invalid wallet address"
+            }))
+            .into_response();
+        }
+    };
+
+    match rpc.get_balance(&pubkey) {
+        Ok(lamports) => {
+            let sol = lamports as f64 / 1_000_000_000.0;
+            Json(json!({
+                "success": true,
+                "data": {
+                    "address": payload.address,
+                    "lamports": lamports,
+                    "sol": sol,
+                    "network": payload.network
+                }
+            }))
+            .into_response()
+        }
+        Err(e) => Json(json!({
+            "success": false,
+            "error": format!("Failed to get balance: {}", e)
+        }))
+        .into_response(),
+    }
+}
+
+async fn get_default_network(State(state): State<AppState>) -> impl IntoResponse {
+    Json(json!({
+        "network": state.default_network
+    }))
+}
+
+#[tokio::main]
+async fn main() {
+    let state = AppState {
+        default_network: "mainnet-beta".to_string(),
+    };
+
+    let cors = CorsLayer::new()
+        .allow_methods([Method::GET, Method::POST])
+        .allow_headers(Any)
+        .allow_origin(Any);
+
+    let app = Router::new()
+        .route("/", get(|| async { "Fuego Server 🔥" }))
+        .route("/health", get(health_check))
+        .route("/network", get(get_default_network))
+        .route("/latest-hash", post(get_latest_hash))
+        .route("/balance", post(get_balance))
+        .layer(cors)
+        .with_state(state);
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
+    println!("🔥 Fuego server running on http://{}", addr);
+    println!("Endpoints:");
+    println!("  POST /latest-hash - Get latest blockhash");
+    println!("  POST /balance - Get SOL balance for address");
+    println!("  GET  /health - Health check");
+    println!("  GET  /network - Get default network");
+
+    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}

--- a/server/src/utils/mod.rs
+++ b/server/src/utils/mod.rs
@@ -1,0 +1,10 @@
+use solana_sdk::{signature::{Signature, ParseSignatureError}, pubkey::{Pubkey, ParsePubkeyError}};
+use std::str::FromStr;
+
+pub fn string_to_pub_key(account: &str) -> Result<Pubkey, ParsePubkeyError> {
+    Pubkey::from_str(account)
+}
+
+pub fn string_to_signature(transaction: &str) -> Result<Signature, ParseSignatureError> {
+    Signature::from_str(transaction)
+}


### PR DESCRIPTION
- New server/ directory with Rust + Tokio + Axum
- Endpoints: POST /latest-hash, POST /balance, GET /health
- Uses solana-sdk pattern from Yumi reference
- Agents can query localhost:8080 for blockhash/balance
- No need for agents to connect to RPC directly
- Updated README with server docs and usage examples

Part of Phase 2: Solana RPC integration