### PR TITLE
Add USDC and PYUSD balance endpoints with configurable commitment

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -11,9 +11,14 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::commitment_config::CommitmentConfig;
+use spl_associated_token_account::get_associated_token_address;
 use std::net::SocketAddr;
 use tower_http::cors::{Any, CorsLayer};
 use utils::string_to_pub_key;
+
+// Token mint addresses
+const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const PYUSD_MINT: &str = "PyUvTEBjM1yGH3FPz8fs9cTSMUq534YEGU3RLWQ5o9t";
 
 #[derive(Serialize, Deserialize)]
 struct RpcNetwork {
@@ -27,15 +32,38 @@ struct GetBalanceRequest {
 }
 
 #[derive(Serialize, Deserialize)]
+struct GetTokenBalanceRequest {
+    network: String,
+    address: String,
+    #[serde(default)]
+    commitment: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
 struct BalanceResponse {
     lamports: u64,
     sol: f64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct TokenBalanceResponse {
+    amount: String,
+    decimals: u8,
+    ui_amount: String,
 }
 
 // State to hold RPC clients (could be expanded for caching)
 #[derive(Clone)]
 struct AppState {
     default_network: String,
+}
+
+fn get_commitment_config(commitment: &Option<String>) -> CommitmentConfig {
+    match commitment.as_ref().map(|s| s.as_str()) {
+        Some("processed") => CommitmentConfig::processed(),
+        Some("finalized") => CommitmentConfig::finalized(),
+        _ => CommitmentConfig::confirmed(),
+    }
 }
 
 async fn health_check() -> impl IntoResponse {
@@ -114,6 +142,112 @@ async fn get_default_network(State(state): State<AppState>) -> impl IntoResponse
     }))
 }
 
+async fn get_usdc_balance(
+    State(_state): State<AppState>,
+    Json(payload): Json<GetTokenBalanceRequest>,
+) -> Response {
+    let rpc_url = format!("https://api.{}.solana.com", payload.network);
+    let commitment = get_commitment_config(&payload.commitment);
+    let rpc = RpcClient::new_with_commitment(rpc_url, commitment);
+
+    let pubkey = match string_to_pub_key(&payload.address) {
+        Ok(pk) => pk,
+        Err(_) => {
+            return Json(json!({
+                "success": false,
+                "error": "Invalid wallet address"
+            }))
+            .into_response();
+        }
+    };
+
+    let usdc_mint = match string_to_pub_key(USDC_MINT) {
+        Ok(mint) => mint,
+        Err(_) => {
+            return Json(json!({
+                "success": false,
+                "error": "Failed to parse USDC mint"
+            }))
+            .into_response();
+        }
+    };
+
+    let associated_token_account = get_associated_token_address(&pubkey, &usdc_mint);
+
+    match rpc.get_token_account_balance(&associated_token_account) {
+        Ok(balance) => Json(json!({
+            "success": true,
+            "data": {
+                "address": payload.address,
+                "amount": balance.amount,
+                "decimals": balance.decimals,
+                "ui_amount": balance.ui_amount_string,
+                "network": payload.network,
+                "token": "USDC"
+            }
+        }))
+        .into_response(),
+        Err(e) => Json(json!({
+            "success": false,
+            "error": format!("Failed to get USDC balance: {}", e)
+        }))
+        .into_response(),
+    }
+}
+
+async fn get_pyusd_balance(
+    State(_state): State<AppState>,
+    Json(payload): Json<GetTokenBalanceRequest>,
+) -> Response {
+    let rpc_url = format!("https://api.{}.solana.com", payload.network);
+    let commitment = get_commitment_config(&payload.commitment);
+    let rpc = RpcClient::new_with_commitment(rpc_url, commitment);
+
+    let pubkey = match string_to_pub_key(&payload.address) {
+        Ok(pk) => pk,
+        Err(_) => {
+            return Json(json!({
+                "success": false,
+                "error": "Invalid wallet address"
+            }))
+            .into_response();
+        }
+    };
+
+    let pyusd_mint = match string_to_pub_key(PYUSD_MINT) {
+        Ok(mint) => mint,
+        Err(_) => {
+            return Json(json!({
+                "success": false,
+                "error": "Failed to parse PYUSD mint"
+            }))
+            .into_response();
+        }
+    };
+
+    let associated_token_account = get_associated_token_address(&pubkey, &pyusd_mint);
+
+    match rpc.get_token_account_balance(&associated_token_account) {
+        Ok(balance) => Json(json!({
+            "success": true,
+            "data": {
+                "address": payload.address,
+                "amount": balance.amount,
+                "decimals": balance.decimals,
+                "ui_amount": balance.ui_amount_string,
+                "network": payload.network,
+                "token": "PYUSD"
+            }
+        }))
+        .into_response(),
+        Err(e) => Json(json!({
+            "success": false,
+            "error": format!("Failed to get PYUSD balance: {}", e)
+        }))
+        .into_response(),
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let state = AppState {
@@ -131,6 +265,8 @@ async fn main() {
         .route("/network", get(get_default_network))
         .route("/latest-hash", post(get_latest_hash))
         .route("/balance", post(get_balance))
+        .route("/usdc-balance", post(get_usdc_balance))
+        .route("/pyusd-balance", post(get_pyusd_balance))
         .layer(cors)
         .with_state(state);
 
@@ -139,6 +275,8 @@ async fn main() {
     println!("Endpoints:");
     println!("  POST /latest-hash - Get latest blockhash");
     println!("  POST /balance - Get SOL balance for address");
+    println!("  POST /usdc-balance - Get USDC balance (default: confirmed commitment)");
+    println!("  POST /pyusd-balance - Get PYUSD balance (default: confirmed commitment)");
     println!("  GET  /health - Health check");
     println!("  GET  /network - Get default network");
 


### PR DESCRIPTION
- New POST /usdc-balance endpoint for USDC token balance checks
- New POST /pyusd-balance endpoint for PYUSD token balance checks
- Optional commitment parameter (defaults to confirmed if not specified)
- Supports processed, confirmed, and finalized commitment levels
- Uses correct mint addresses: USDC (legacy), PYUSD (tokenProgram)
- Returns amount, decimals, and ui_amount for token balance